### PR TITLE
refector(script): use random password for createAdmin

### DIFF
--- a/src/scripts/createAdmin.ts
+++ b/src/scripts/createAdmin.ts
@@ -1,8 +1,10 @@
+import { nanoid } from 'nanoid';
 import { UserController } from '../controllers/user';
 
 const userController = new UserController();
-await userController.register({ username: 'admin', id: 'admin', password: '12345678', role: 'admin' });
-console.log('Created default admin user. \nUserID: `admin` \nUsername: `admin` \nPassword: `12345678`');
-const admin = await userController.login('admin', '12345678');
+const password = nanoid(10);
+await userController.register({ username: 'admin', id: 'admin', password: password, role: 'admin' });
+console.log(`Created default admin user. \nUserID: 'admin' \nUsername: 'admin' \nPassword: '${password}'`);
+const admin = await userController.login('admin', password);
 console.log('Admin AccessToken:');
 console.log(admin?.accessToken);


### PR DESCRIPTION
This is to prevent admin password leaks when the createAdmin script is used in production and the password is never modified.